### PR TITLE
Use url to seed initial state of app

### DIFF
--- a/src/app.bs.js
+++ b/src/app.bs.js
@@ -12,6 +12,20 @@ var ReasonReact = require("reason-react/src/ReasonReact.js");
 
 var component = ReasonReact.reducerComponent("App");
 
+function urlToRoute(url) {
+  var match = url[/* path */0];
+  if (match && match[0] === "view") {
+    var match$1 = match[1];
+    if (match$1 && !match$1[1]) {
+      return /* Detail */[match$1[0]];
+    } else {
+      return /* Default */0;
+    }
+  } else {
+    return /* Default */0;
+  }
+}
+
 function make() {
   return /* record */[
           /* debugName */component[/* debugName */0],
@@ -20,17 +34,7 @@ function make() {
           /* willReceiveProps */component[/* willReceiveProps */3],
           /* didMount */(function (self) {
               var watcherID = ReasonReact.Router[/* watchUrl */1]((function (url) {
-                      var match = url[/* path */0];
-                      if (match && match[0] === "view") {
-                        var match$1 = match[1];
-                        if (match$1 && !match$1[1]) {
-                          return Curry._1(self[/* send */3], /* ChangeRoute */[/* Detail */[match$1[0]]]);
-                        } else {
-                          return Curry._1(self[/* send */3], /* ChangeRoute */[/* Default */0]);
-                        }
-                      } else {
-                        return Curry._1(self[/* send */3], /* ChangeRoute */[/* Default */0]);
-                      }
+                      return Curry._1(self[/* send */3], /* ChangeRoute */[urlToRoute(url)]);
                     }));
               return Curry._1(self[/* onUnmount */4], (function () {
                             return ReasonReact.Router[/* unwatchUrl */2](watcherID);
@@ -61,7 +65,7 @@ function make() {
                         ],
                         /* [] */0
                       ],
-                      /* activeRoute : Detail */["hello"]
+                      /* activeRoute */urlToRoute(ReasonReact.Router[/* dangerouslyGetInitialUrl */3](/* () */0))
                     ];
             }),
           /* retainedProps */component[/* retainedProps */11],
@@ -80,5 +84,6 @@ function make() {
 }
 
 exports.component = component;
+exports.urlToRoute = urlToRoute;
 exports.make = make;
 /*  Not a pure module */

--- a/src/app.re
+++ b/src/app.re
@@ -15,6 +15,12 @@ type action =
 
 let component = ReasonReact.reducerComponent("App");
 
+let urlToRoute = url =>
+  switch (ReasonReact.Router.(url.path)) {
+  | ["view", postId] => Detail(postId)
+  | _ => Default
+  };
+
 let make = _children => {
   ...component,
   initialState: () => {
@@ -26,15 +32,16 @@ let make = _children => {
         description: "cat",
       },
     ],
-    activeRoute: Detail("hello"),
+    activeRoute: {
+      /* See https://reasonml.github.io/reason-react/docs/en/router#directly-get-a-route */
+      let url = ReasonReact.Router.dangerouslyGetInitialUrl();
+      urlToRoute(url);
+    },
   },
   didMount: self => {
     let watcherID =
       ReasonReact.Router.watchUrl(url =>
-        switch (url.path) {
-        | ["view", postId] => self.send(ChangeRoute(Detail(postId)))
-        | _ => self.send(ChangeRoute(Default))
-        }
+        self.send(ChangeRoute(urlToRoute(url)))
       );
     self.onUnmount(() => ReasonReact.Router.unwatchUrl(watcherID));
   },


### PR DESCRIPTION
See https://reasonml.github.io/reason-react/docs/en/router#directly-get-a-route for more background.

Makes sure the correct page is displayed when the browser is refreshed, by seeding the initial state with the url from the router.