### PR TITLE
Hook router into state + open Belt w/ compiler flag

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -14,7 +14,8 @@
     "react-jsx": 2
   },
   "bsc-flags": [
-    "-bs-super-errors"
+    "-bs-super-errors",
+    "-open Belt"
   ],
   "refmt": 3,
   "package-specs": {

--- a/src/Types.js
+++ b/src/Types.js
@@ -3,6 +3,33 @@
 
 var Json_decode = require("@glennsl/bs-json/src/Json_decode.bs.js");
 
+function urlToRoute(url) {
+  var match = url[/* path */0];
+  if (match && match[0] === "view") {
+    var match$1 = match[1];
+    if (match$1 && !match$1[1]) {
+      return /* Detail */[match$1[0]];
+    } else {
+      return /* Base */0;
+    }
+  } else {
+    return /* Base */0;
+  }
+}
+
+function toUrl(url) {
+  if (url) {
+    return "/view/" + (String(url[0]) + "");
+  } else {
+    return "/";
+  }
+}
+
+var Route = /* module */[
+  /* urlToRoute */urlToRoute,
+  /* toUrl */toUrl
+];
+
 function decode(from, json) {
   return Json_decode.field("data", (function (param) {
                 return Json_decode.list(from, param);
@@ -78,6 +105,7 @@ var Post = /* module */[
   /* decode */decode$2
 ];
 
+exports.Route = Route;
 exports.decode = decode;
 exports.Caption = Caption;
 exports.Num = Num;

--- a/src/Types.re
+++ b/src/Types.re
@@ -1,6 +1,20 @@
-type route =
-  | Base
-  | Detail(string);
+module Route = {
+  type t =
+    | Base
+    | Detail(string);
+
+  let urlToRoute = url =>
+    switch (ReasonReact.Router.(url.path)) {
+    | ["view", postId] => Detail(postId)
+    | _ => Base
+    };
+
+  let toUrl = url =>
+    switch (url) {
+    | Detail(postId) => {j|/view/$postId|j}
+    | Base => "/"
+    };
+};
 
 let decode = (from, json) =>
   Json.Decode.(json |> field("data", list(from)));

--- a/src/app.js
+++ b/src/app.js
@@ -17,20 +17,6 @@ var component = ReasonReact.reducerComponent("App");
 
 var token = (process.env.API_TOKEN);
 
-function urlToRoute(url) {
-  var match = url[/* path */0];
-  if (match && match[0] === "view") {
-    var match$1 = match[1];
-    if (match$1 && !match$1[1]) {
-      return /* Detail */[match$1[0]];
-    } else {
-      return /* Base */0;
-    }
-  } else {
-    return /* Base */0;
-  }
-}
-
 function make() {
   return /* record */[
           /* debugName */component[/* debugName */0],
@@ -39,7 +25,7 @@ function make() {
           /* willReceiveProps */component[/* willReceiveProps */3],
           /* didMount */(function (self) {
               var watcher = ReasonReact.Router[/* watchUrl */1]((function (url) {
-                      return Curry._1(self[/* send */3], /* ChangeRoute */Block.__(4, [urlToRoute(url)]));
+                      return Curry._1(self[/* send */3], /* ChangeRoute */Block.__(4, [Types.Route[/* urlToRoute */0](url)]));
                     }));
               Curry._1(self[/* send */3], /* FetchPosts */0);
               return Curry._1(self[/* onUnmount */4], (function () {
@@ -53,9 +39,9 @@ function make() {
           /* render */(function (param) {
               var send = param[/* send */3];
               var state = param[/* state */1];
-              var onClick = function (route, e) {
+              var navigate = function (route, e) {
                 e.preventDefault();
-                return Curry._1(send, /* ChangeRoute */Block.__(4, [route]));
+                return ReasonReact.Router[/* push */0](Types.Route[/* toUrl */1](route));
               };
               var onLike = function (post, like) {
                 return Curry._1(send, /* Like */Block.__(3, [
@@ -69,12 +55,12 @@ function make() {
               } else {
                 var posts = state[1];
                 var route = state[0];
-                tmp = route ? ReasonReact.element(undefined, undefined, Single.make(posts, route[0], onLike, onClick, /* array */[])) : ReasonReact.element(undefined, undefined, Grid.make(posts, onLike, onClick, /* array */[]));
+                tmp = route ? ReasonReact.element(undefined, undefined, Single.make(posts, route[0], onLike, navigate, /* array */[])) : ReasonReact.element(undefined, undefined, Grid.make(posts, onLike, navigate, /* array */[]));
               }
               return React.createElement("div", undefined, React.createElement("h1", undefined, React.createElement("a", {
                                   href: "/",
                                   onClick: (function (param) {
-                                      return onClick(/* Base */0, param);
+                                      return navigate(/* Base */0, param);
                                     })
                                 }, "Catstagram")), tmp);
             }),
@@ -124,7 +110,7 @@ function make() {
                                   })]);
                   case 1 : 
                       return /* Update */Block.__(0, [/* Loaded */[
-                                  urlToRoute(ReasonReact.Router[/* dangerouslyGetInitialUrl */3](/* () */0)),
+                                  Types.Route[/* urlToRoute */0](ReasonReact.Router[/* dangerouslyGetInitialUrl */3](/* () */0)),
                                   action[0]
                                 ]]);
                   case 2 : 
@@ -178,32 +164,30 @@ function make() {
                                           }))
                                   ]]);
                   case 4 : 
-                      var route = action[0];
                       return /* UpdateWithSideEffects */Block.__(2, [
                                 typeof state === "number" ? state : /* Loaded */[
-                                    route,
+                                    action[0],
                                     state[1]
                                   ],
                                 (function (param) {
                                     var state = param[/* state */1];
-                                    if (route) {
-                                      var id = route[0];
-                                      var tmp;
-                                      if (typeof state === "number") {
-                                        tmp = false;
-                                      } else {
-                                        var match = Belt_List.getBy(state[1], (function (p) {
+                                    if (typeof state === "number") {
+                                      return /* () */0;
+                                    } else {
+                                      var match = state[0];
+                                      if (match) {
+                                        var id = match[0];
+                                        var p = Belt_List.getBy(state[1], (function (p) {
                                                 return p[/* id */0] === id;
                                               }));
-                                        tmp = match !== undefined && !match[/* comments */6] ? true : false;
-                                      }
-                                      if (tmp) {
-                                        return Curry._1(param[/* send */3], /* FetchComments */Block.__(0, [id]));
+                                        if (p !== undefined && !p[/* comments */6]) {
+                                          return Curry._1(param[/* send */3], /* FetchComments */Block.__(0, [id]));
+                                        } else {
+                                          return /* () */0;
+                                        }
                                       } else {
                                         return /* () */0;
                                       }
-                                    } else {
-                                      return /* () */0;
                                     }
                                   })
                               ]);
@@ -215,14 +199,10 @@ function make() {
         ];
 }
 
-var B = 0;
-
 var T = 0;
 
-exports.B = B;
 exports.T = T;
 exports.component = component;
 exports.token = token;
-exports.urlToRoute = urlToRoute;
 exports.make = make;
 /* component Not a pure module */

--- a/src/comments.js
+++ b/src/comments.js
@@ -50,9 +50,6 @@ function make(comments, _) {
         ];
 }
 
-var B = 0;
-
 exports.component = component;
-exports.B = B;
 exports.make = make;
 /* component Not a pure module */

--- a/src/comments.re
+++ b/src/comments.re
@@ -1,7 +1,5 @@
 let component = ReasonReact.statelessComponent("Comments");
 
-module B = Belt;
-
 let make = (~comments, _children) => {
   ...component,
   render: _self =>
@@ -9,7 +7,7 @@ let make = (~comments, _children) => {
       <div className="comments-list">
         {
           comments
-          ->B.List.map(({Types.Comment.id, text, from: {username}}) =>
+          ->List.map(({Types.Comment.id, text, from: {username}}) =>
               <div className="comment" key=id>
                 <p>
                   <strong> {ReasonReact.string(username)} </strong>
@@ -20,7 +18,7 @@ let make = (~comments, _children) => {
                 </p>
               </div>
             )
-          |> B.List.toArray
+          |> List.toArray
           |> ReasonReact.array
         }
       </div>

--- a/src/grid.js
+++ b/src/grid.js
@@ -8,7 +8,7 @@ var ReasonReact = require("reason-react/src/ReasonReact.js");
 
 var component = ReasonReact.statelessComponent("Grid");
 
-function make(posts, onLike, onClick, _) {
+function make(posts, onLike, navigate, _) {
   return /* record */[
           /* debugName */component[/* debugName */0],
           /* reactClassInternal */component[/* reactClassInternal */1],
@@ -23,7 +23,7 @@ function make(posts, onLike, onClick, _) {
               return React.createElement("div", {
                           className: "photo-grid"
                         }, Belt_List.toArray(Belt_List.map(posts, (function (post) {
-                                    return ReasonReact.element(post[/* id */0], undefined, Post.make(post, onLike, onClick, /* array */[]));
+                                    return ReasonReact.element(post[/* id */0], undefined, Post.make(post, onLike, navigate, /* array */[]));
                                   }))));
             }),
           /* initialState */component[/* initialState */10],
@@ -33,9 +33,6 @@ function make(posts, onLike, onClick, _) {
         ];
 }
 
-var B = 0;
-
 exports.component = component;
-exports.B = B;
 exports.make = make;
 /* component Not a pure module */

--- a/src/grid.re
+++ b/src/grid.re
@@ -1,16 +1,14 @@
 let component = ReasonReact.statelessComponent("Grid");
 
-module B = Belt;
-
-let make = (~posts, ~onLike, ~onClick, _children) => {
+let make = (~posts, ~onLike, ~navigate, _children) => {
   ...component,
   render: _self =>
     <div className="photo-grid">
       {
-        B.List.map(posts, post =>
-          <Post key={post.Types.Post.id} post onLike onClick />
+        List.map(posts, post =>
+          <Post key={post.Types.Post.id} post onLike navigate />
         )
-        |> B.List.toArray
+        |> List.toArray
         |> ReasonReact.array
       }
     </div>,

--- a/src/post.js
+++ b/src/post.js
@@ -7,7 +7,7 @@ var ReasonReact = require("reason-react/src/ReasonReact.js");
 
 var component = ReasonReact.statelessComponent("Post");
 
-function make(post, onLike, onClick, _) {
+function make(post, onLike, navigate, _) {
   return /* record */[
           /* debugName */component[/* debugName */0],
           /* reactClassInternal */component[/* reactClassInternal */1],
@@ -28,7 +28,7 @@ function make(post, onLike, onClick, _) {
                               className: "grid-photo-wrap"
                             }, React.createElement("a", {
                                   href: "/view/" + (String(id) + ""),
-                                  onClick: Curry._1(onClick, /* Detail */[id])
+                                  onClick: Curry._1(navigate, /* Detail */[id])
                                 }, React.createElement("img", {
                                       className: "grid-photo",
                                       alt: id,
@@ -43,7 +43,7 @@ function make(post, onLike, onClick, _) {
                                     }, "♥ " + (String(likes) + "")), React.createElement("a", {
                                       className: "button",
                                       href: "/view/" + (String(id) + ""),
-                                      onClick: Curry._1(onClick, /* Detail */[id])
+                                      onClick: Curry._1(navigate, /* Detail */[id])
                                     }, React.createElement("span", {
                                           className: "comment-count"
                                         }, React.createElement("span", {

--- a/src/post.re
+++ b/src/post.re
@@ -2,7 +2,7 @@ let component = ReasonReact.statelessComponent("Post");
 
 open Types;
 
-let make = (~post, ~onLike, ~onClick, _children) => {
+let make = (~post, ~onLike, ~navigate, _children) => {
   ...component,
   render: _self => {
     let {
@@ -16,7 +16,7 @@ let make = (~post, ~onLike, ~onClick, _children) => {
     let likes = string_of_int(count);
     <figure className="grid-figure">
       <div className="grid-photo-wrap">
-        <a href={j|/view/$id|j} onClick={onClick(Detail(id))}>
+        <a href={j|/view/$id|j} onClick={navigate(Route.Detail(id))}>
           <img src=url alt=id className="grid-photo" />
         </a>
       </div>
@@ -31,7 +31,7 @@ let make = (~post, ~onLike, ~onClick, _children) => {
           <a
             className="button"
             href={j|/view/$id|j}
-            onClick={onClick(Detail(id))}>
+            onClick={navigate(Detail(id))}>
             <span className="comment-count">
               <span className="speech-bubble" />
               {ReasonReact.string(string_of_int(num_comments))}

--- a/src/single.js
+++ b/src/single.js
@@ -10,7 +10,7 @@ var ReasonReact = require("reason-react/src/ReasonReact.js");
 
 var component = ReasonReact.statelessComponent("Single");
 
-function make(posts, postId, onLike, onClick, _) {
+function make(posts, postId, onLike, navigate, _) {
   return /* record */[
           /* debugName */component[/* debugName */0],
           /* reactClassInternal */component[/* reactClassInternal */1],
@@ -29,7 +29,7 @@ function make(posts, postId, onLike, onClick, _) {
                 var post = match;
                 return React.createElement("div", {
                             className: "single-photo"
-                          }, ReasonReact.element(undefined, undefined, Post.make(post, onLike, onClick, /* array */[])), ReasonReact.element(undefined, undefined, Comments.make(post[/* comments */6], /* array */[])));
+                          }, ReasonReact.element(undefined, undefined, Post.make(post, onLike, navigate, /* array */[])), ReasonReact.element(undefined, undefined, Comments.make(post[/* comments */6], /* array */[])));
               } else {
                 return ReasonReact.element(undefined, undefined, $$Error.make(/* array */[]));
               }

--- a/src/single.re
+++ b/src/single.re
@@ -1,13 +1,13 @@
 let component = ReasonReact.statelessComponent("Single");
 
-let make = (~posts, ~postId, ~onLike, ~onClick, _children) => {
+let make = (~posts, ~postId, ~onLike, ~navigate, _children) => {
   ...component,
   render: _self =>
     switch (posts->Belt.List.getBy(({Types.Post.id}) => id == postId)) {
     | None => <Error />
     | Some(post) =>
       <div className="single-photo">
-        <Post post onLike onClick />
+        <Post post onLike navigate />
         <Comments comments={post.comments} />
       </div>
     },


### PR DESCRIPTION
- `open Belt` by default with compiler flag
- simplify a pattern match
- Connect the app navigation to the url, through Reason's router:

1) ReasonReact.Router.push(url) triggers all subscriptions
2)
```reason
      ReasonReact.Router.watchUrl(url =>
        self.send(ChangeRoute(T.Route.urlToRoute(url)))
      );
```
3)  the reducer in `app.re` receives the `ChangeRoute` action, and we update the state 